### PR TITLE
[WIP] Do not pass root attribute if empty

### DIFF
--- a/src/connection/database/actions.js
+++ b/src/connection/database/actions.js
@@ -84,7 +84,9 @@ export function signUp(id) {
         const fieldValue = c.getFieldValue(m, x.get('name'));
         switch (storage) {
           case 'root':
-            params[fieldName] = fieldValue;
+            if (fieldValue) {
+              params[fieldName] = fieldValue;
+            }
             break;
           default:
             if (!params.user_metadata) {


### PR DESCRIPTION
The API does not accept empty string or null for root attributes, which is a problem when that attribute is optional.